### PR TITLE
Py3kcompat

### DIFF
--- a/mxiostat.py
+++ b/mxiostat.py
@@ -633,7 +633,11 @@ def process(args):
 		sys.exit(1)
 
 if __name__ == "__main__":
-	process(sys.argv[1:])
+	try:
+		process(sys.argv[1:])
+	except KeyboardInterrupt:
+		print
+		sys.exit(0)
 
 #
 # -----


### PR DESCRIPTION
Running this script in parallel on py2,3 and the unmodified mxiostat all produces the same magnitude output when compared, so I don't believe this adds any bugs. Some code changes though.
